### PR TITLE
added FSR photon recovery to NanoAOD

### DIFF
--- a/python/fsr_cfi.py
+++ b/python/fsr_cfi.py
@@ -1,0 +1,24 @@
+import FWCore.ParameterSet.Config as cms
+from FSRPhotonRecovery.FSRPhotons.FSRphotonSequence_cff import addFSRphotonSequence
+from PhysicsTools.NanoAOD.common_cff import Var, P4Vars
+
+def addFSRphotonNano(process):
+    addFSRphotonSequence(process, 'slimmedMuons', "FSRPhotonRecovery/FSRPhotons/data/PhotonMVAv9_BDTG800TreesDY.weights.xml")
+    process.fsrPhotonTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
+        src = cms.InputTag("FSRRecovery", "selectedFSRphotons"),
+        cut = cms.string(""), #we should not filter on cross linked collections
+        name = cms.string("FSRPhoton"),
+        doc  = cms.string("FSR photons"),
+        singleton = cms.bool(False),
+        extension = cms.bool(False),
+        variables = cms.PSet(
+            P4Vars,
+            photonMVAIdValue = Var("userFloat('photonMVAIdValue')",float,doc="Photon MVA ID value"),
+            FSRphotonMVAValue = Var("userFloat('FSRphotonMVAValue')",float,doc="Photon FSR MVA value"),
+            PFphotonIso03 = Var("userFloat('PFphotonIso03')",float,doc="Isolation"),
+        )
+    )
+    
+    process.FSRphotonSequence += process.fsrPhotonTable
+    process.fsr_step = cms.Path(process.FSRphotonSequence)
+    process.schedule.insert(0, process.fsr_step)

--- a/python/myNanoProdData_NANO.py
+++ b/python/myNanoProdData_NANO.py
@@ -86,3 +86,6 @@ process.add_(cms.Service('InitRootHandlers', EnableIMT = cms.untracked.bool(Fals
 from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete
 process = customiseEarlyDelete(process)
 # End adding early deletion
+
+from MyAnalysis.HmmAna.fsr_cfi import addFSRphotonNano
+addFSRphotonNano(process)

--- a/python/myNanoProdMc_NANO.py
+++ b/python/myNanoProdMc_NANO.py
@@ -87,3 +87,11 @@ process = nanoAOD_customizeMC(process)
 from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete
 process = customiseEarlyDelete(process)
 # End adding early deletion
+
+from MyAnalysis.HmmAna.fsr_cfi import addFSRphotonNano
+addFSRphotonNano(process)
+
+#for debugging
+#with open("dump.py", "w") as fi:
+#    fi.write(process.dumpPython())
+

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -5,3 +5,4 @@ git cms-addpkg cms-nanoAOD:master-102X
 git checkout -b nanoAOD cms-nanoAOD/master-102X
 git clone https://github.com/cms-nanoAOD/nanoAOD-tools.git PhysicsTools/NanoAODTools
 git clone https://github.com/irenedutta23/HmmAna.git MyAnalysis/HmmAna
+git clone https://gitlab.cern.ch/uhh-cmssw/fsr-photon-recovery.git FSRPhotonRecovery


### PR DESCRIPTION
Added the FSR recovery recipe from https://gitlab.cern.ch/uhh-cmssw/fsr-photon-recovery/tree/master to our NanoAOD configuration. NanoAOD produced with the modified configurations will contain additional branches `FSRPhoton_*`.

~~~
root [1] Events->Scan("FSRPhoton_pt:FSRPhoton_eta:FSRPhoton_phi:FSRPhoton_photonMVAIdValue:FSRPhoton_FSRphotonMVAValue:FSRPhoton_PFphotonIso03", "nFSRPhoton>0")
***********************************************************************************************
*    Row   * Instance * FSRPhoton * FSRPhoton * FSRPhoton * FSRPhoton * FSRPhoton * FSRPhoton *
***********************************************************************************************
*        8 *        0 * 2.3691406 * -0.235290 * -2.844726 *       -10 * -0.925432 * 1.7923536 *
*       11 *        0 *  3.984375 * -1.121826 * -2.982910 *       -10 * 0.7159917 * 0.7364583 *
*       11 *        1 * 2.4511718 * -0.782226 * 0.0004923 *       -10 * -0.891979 * 3.5034861 *
*       13 *        0 * 2.0898437 * 0.5594482 * 0.5024414 *       -10 * -0.889623 * 39.715419 *
*       13 *        1 *    8.6875 * 0.5034179 * 0.6940917 *       -10 * -0.296340 * 9.6812610 *
*       13 *        2 * 7.3046875 * 0.4815673 * 0.6523437 *       -10 * -0.557832 * 11.701036 *
*       13 *        3 * 2.2226562 * 0.5394287 * 0.6439208 *       -10 * -0.903787 * 39.682228 *
*       13 *        4 * 2.2050781 * 0.5028076 * 0.5447998 *       -10 * -0.935594 * 39.650798 *
*       18 *        0 * 2.0371093 * 1.9565429 * 1.3171386 *       -10 * -0.852417 * 3.4988014 *
~~~